### PR TITLE
Fixed cronus initial beam invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Current Changes & Bugfixes Tracklist
 
+2021-1-23
+[ReduxGelum]
+- Fixed cronus initial beam effect invisible on low graphics settings
+
 2021-1-21
 [ReduxGelum]
 - Overall enemy pathing optimization - preventing units from getting stuck and causing lag.
-- As a result certain exploit spots are no long effective.
+- As a result certain exploit spots are no longer effective.
  
-- [LeoTheCat]
+[LeoTheCat]
 - Fixed the inner radius of Eos and some other enemies so that they don't get stuck. This radius does not affect Flamethrower MK-3 dps.
 - Storyline selection UI will now reflect lobby options for consistency (e.g. High Spawn should be highlighted if lobby option is set so).
 - Realism command has been removed as pretty much all controversial changes have been reverted to the original.

--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ModelData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ModelData.xml
@@ -2793,7 +2793,7 @@
         <Model value="Assets\Effects\Protoss\DisruptionWeb\DisruptionWeb.m3"/>
     </CModel>
     <CModel id="PunchImpact" parent="ImpactFX">
-        <Model value="Assets\Effects\Other\GenericImpactSmear\GenericImpactSmear.m3"/>
+        <Model value="Assets\Effects\Protoss\ZeratulBlinkIn\ZeratulBlinkIn.m3"/>
         <EditorCategories value="Race:Terran"/>
         <Lighting value="SiegeTankAttackImpact"/>
         <LowQualityModel value="PunchImpact"/>


### PR DESCRIPTION
on low settings initial beams are invisible, forcing players to pick medium/high just for cronus